### PR TITLE
Style tweaks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -117,11 +117,15 @@ body {
   margin: 0 0.3em 0 0;
 }
 
-.online {
+.status-online {
   background-color: #79e740;
 }
 
-.offline {
+.status-offline {
   background-color: #999;
   border-radius: 0px;
+}
+
+.status-unknown {
+  border-radius: 33%;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 body {
-  background: #ebe8f6;
+  background: #8f89a6;
   font-family: "Gill Sans";
 }
 
@@ -55,11 +55,19 @@ body {
   border-radius: 8px;
   padding: 10px;
   background: #e0e2f6;
-  box-shadow: 2px 2px 5px 0 rgba(0, 0, 0, 0.05);
+  box-shadow: 2px 2px 10px 0 rgba(0, 0, 0, 0.12);
 }
 
-.status:last-child {
-  margin: 0;
+.status.old {
+  opacity: 0.55;
+  background: #d4d5d9;
+  box-shadow: 2px 2px 7px 0 rgba(0, 0, 0, 0.07);
+}
+
+.status.ancient {
+  opacity: 0.4;
+  background: #d1b9b9;
+  box-shadow: none;
 }
 
 .status-text {
@@ -98,7 +106,8 @@ body {
   width: 0.6em;
   height: 0.6em;
   display: inline-block;
-  border-radius: 50%;
+  border-radius: 60%;
+  border: 1px solid rgb(0,0,0,0.7);
   margin: 0 0.3em 0 0;
 }
 
@@ -107,5 +116,6 @@ body {
 }
 
 .offline {
-  background-color: rgba(200, 200, 200);
+  background-color: #999;
+  border-radius: 0px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -49,8 +49,8 @@ body {
 .status {
   list-style: none;
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-areas: "text text" "author author";
+  grid-template-columns: 2fr 1fr;
+  grid-template-areas: "text text" "author timestamp";
   margin: 0 8px 1em 8px;
   border-radius: 8px;
   padding: 10px;
@@ -77,17 +77,23 @@ body {
   padding: 12px;
   border-radius: 8px;
   margin: 0 0 0.4em 0;
+
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .status-author {
   grid-area: author;
   margin: 0;
+
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .status-timestamp {
+  grid-area: timestamp;
   text-align: right;
   color: #888;
-  grid-area: time;
   margin: 0;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,7 +297,7 @@ function Status({ doc }: StatusProps) {
           authorAddress={doc.author}
           workspaceAddress={doc.workspace}
         />
-        <strong>
+        <strong title={doc.author}>
           {displayNameDoc ? (
             displayNameDoc.content
           ) : (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -304,7 +304,9 @@ function Status({ doc }: StatusProps) {
             <AuthorLabel address={doc.author} />
           )}
         </strong>
-        <span className={"status-timestamp"}> {agoString}</span>
+      </p>
+      <p className={"status-timestamp"}>
+        {agoString}
       </p>
     </li>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,11 +258,11 @@ type Oldness = "recent" | "old" | "ancient";
 function howOld(date: Date): Oldness {
   const daysOld = (Date.now() - date.getTime()) / 1000 / 60 / 60 / 24;
 
-  if (daysOld > 365) {
+  if (daysOld > 30) {
     return "ancient";
   }
 
-  if (daysOld > 30) {
+  if (daysOld > 2) {
     return "old";
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -339,7 +339,7 @@ function OnlineIndicator({
   }, []);
 
   if (!lastOnlineDoc) {
-    return null;
+    return <span title="unknown status" className={"status-dot status-unknown"}></span>;
   }
 
   const docDate = new Date(lastOnlineDoc.timestamp / 1000);
@@ -349,9 +349,9 @@ function OnlineIndicator({
   const notThere = lastOnlineDoc.content === "";
 
   return notThere ? null : isOnline ? (
-    <span className={"status-dot online"}></span>
+    <span title="online" className={"status-dot status-online"}></span>
   ) : (
-    <span className={"status-dot offline"}></span>
+    <span title="offline" className={"status-dot status-offline"}></span>
   );
 }
 


### PR DESCRIPTION
Lots of little changes!

* Darker page background color for contrast with status boxes
* Fade statuses with age
* Changed age thresholds: 2 days is "old", 30 days is "ancient"
* Show an empty status icon when there's no status.txt, to keep everything aligned
* Status icon changes shape as well as color
* Use grid layout for timestamp to make it right-aligned
* CSS to better wrap super long words in user input and display name
* Show author address as tooltip on hover over display name

![Screen Shot 2021-02-01 at 2 03 32 PM](https://user-images.githubusercontent.com/32660718/106523765-75410700-6496-11eb-8531-c11777b6a59e.png)

It would also be fun to experiment with a much more minimal style like old-school Google Talk's status list on the left here.  Fewer boxes, just whitespace

![google-talk](https://user-images.githubusercontent.com/32660718/106524495-85a5b180-6497-11eb-8dd9-33097f004b81.jpg)